### PR TITLE
Update _index.en.md - Remove 'alpha' wording on Drupal 11 instructions

### DIFF
--- a/content/_index.en.html
+++ b/content/_index.en.html
@@ -13,11 +13,11 @@ title = "Drupal WxT"
       a web content management system which assists in building and
       maintaining multilingual web sites that are accessible, usable, and interoperable.</p>
     <p class="lead mt-2">This distribution complies with the mandatory requirement to implement the <strong><a
-          href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification.html">Content
+          href="https://design.canada.ca/specifications.html">Content
           and Information Architecture (C&IA) Specification</a></strong> as well as consulting the reference
       implementation and
-      design patterns provided by the <strong><a href="https://wet-boew.github.io/GCWeb/index-en.html">Canada.ca design
-          system</a></strong>.</p>
+      design patterns provided by the <strong><a href="https://wet-boew.github.io/GCWeb/index-en.html">GCWeb, the WET-BOEW Canada.ca theme
+      </a></strong>.</p>
     <p class="lead mt-2">This is accomplished through our integration and use of the components provided by the
       <strong><a href="https://github.com/wet-boew/wet-boew">Web Experience Toolkit</a></strong> which undergoes routine
       usability testing as well as provides conformance to the Web Content Accessibility Guideline (WCAG 2.0) and

--- a/content/docs/general/installation/_index.en.md
+++ b/content/docs/general/installation/_index.en.md
@@ -45,7 +45,7 @@ Run the following commands (choosing your version) and replace site-name with th
 composer self-update
 composer create-project drupalwxt/site-wxt:10.4.x-dev <site-name> --no-interaction
 
-# Requires PHP 8.3 (Drupal 11 - alpha release)
+# Requires PHP 8.3 (Drupal 11 - release)
 composer self-update
 composer create-project drupalwxt/site-wxt:11.1.x-dev <site-name> --no-interaction
 ```


### PR DESCRIPTION
Also resolve https://github.com/drupalwxt/drupalwxt.github.io/issues/7
